### PR TITLE
Fix `ScrollView`s getting out of sync when changing `ScrollView` during animation

### DIFF
--- a/Sources/SimultaneouslyScrollView/DefaultSimultaneouslyScrollViewHandler.swift
+++ b/Sources/SimultaneouslyScrollView/DefaultSimultaneouslyScrollViewHandler.swift
@@ -3,7 +3,7 @@ import UIKit
 
 internal class DefaultSimultaneouslyScrollViewHandler: NSObject, SimultaneouslyScrollViewHandler {
     private var scrollViewsStore: WeakObjectStore<UIScrollView> = WeakObjectStore()
-    private var scrollingScrollView: UIScrollView?
+    private weak var lastScrollingScrollView: UIScrollView?
 
     private let scrolledToBottomSubject = PassthroughSubject<Bool, Never>()
 
@@ -63,22 +63,18 @@ internal class DefaultSimultaneouslyScrollViewHandler: NSObject, SimultaneouslyS
 
 extension DefaultSimultaneouslyScrollViewHandler: UIScrollViewDelegate {
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-        scrollingScrollView = scrollView
+        lastScrollingScrollView = scrollView
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         checkIsContentOffsetAtBottom()
 
-        guard scrollingScrollView == scrollView else {
+        guard lastScrollingScrollView == scrollView else {
             return
         }
 
         scrollViewsStore.allObjects
-            .filter { $0 != scrollingScrollView }
+            .filter { $0 != lastScrollingScrollView }
             .forEach { $0.setContentOffset(scrollView.contentOffset, animated: false) }
-    }
-
-    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        scrollingScrollView = nil
     }
 }


### PR DESCRIPTION
## Description

Fixes: #7 

### Problem
When changing the User Interaction from one `ScrollView` to another during the scroll animation is still ongoing, the `ScrollView`s are getting out of sync.

The reason for this was that the `scrollViewWillBeginDragging` from the newly touched `ScrollView` gets called **before** the `scrollViewDidEndDecelerating` was called from the previous `ScrollView`.
Therefor the `scrollingScrollView` became `nil` even though one `ScrollView` was still scrolling.

### Changes
To fix this problem, the resetting of `scrollingScrollView` to `nil` was removed entirely. Instead, the last scrolling `ScrollView` is stored (`weak`) and is used as the only indicator which `ScrollView` is currently dragged by the user.

_Since it is stored `weak`, there should be no memory overhead of doing so._

Note:
We can not utilize the `scrollViewDidEndDragging` delegate method as the declaration animation will end abruptly.