### PR TITLE
Prevent using the Package on other platforms than iOS

### DIFF
--- a/Sources/SimultaneouslyScrollView/DefaultSimultaneouslyScrollViewHandler.swift
+++ b/Sources/SimultaneouslyScrollView/DefaultSimultaneouslyScrollViewHandler.swift
@@ -1,3 +1,4 @@
+#if os(iOS)
 import Combine
 import UIKit
 
@@ -78,3 +79,4 @@ extension DefaultSimultaneouslyScrollViewHandler: UIScrollViewDelegate {
             .forEach { $0.setContentOffset(scrollView.contentOffset, animated: false) }
     }
 }
+#endif

--- a/Sources/SimultaneouslyScrollView/Extensions/UIScrollView+OffsetHelper.swift
+++ b/Sources/SimultaneouslyScrollView/Extensions/UIScrollView+OffsetHelper.swift
@@ -1,3 +1,4 @@
+#if os(iOS)
 import UIKit
 
 internal extension UIScrollView {
@@ -9,3 +10,4 @@ internal extension UIScrollView {
         contentSize.height > bounds.size.height
     }
 }
+#endif

--- a/Sources/SimultaneouslyScrollView/SimultaneouslyScrollViewHandler.swift
+++ b/Sources/SimultaneouslyScrollView/SimultaneouslyScrollViewHandler.swift
@@ -1,8 +1,14 @@
 import Combine
+#if os(iOS)
 import UIKit
+#endif
 
 /// Handler to enable simultaneously scrolling of `ScrollView`s
+@available(iOS 13, *)
+@available(tvOS, unavailable)
+@available(macOS, unavailable)
 public protocol SimultaneouslyScrollViewHandler {
+#if os(iOS)
     /// Publisher to notify if the `ScrollView`s are scrolled to the bottom
     var scrolledToBottomPublisher: AnyPublisher<Bool, Never> { get }
 
@@ -15,4 +21,5 @@ public protocol SimultaneouslyScrollViewHandler {
 
     /// Helper method to scroll all registered `ScrollView`s to the bottom.
     func scrollAllToBottom(animated: Bool)
+#endif
 }

--- a/Sources/SimultaneouslyScrollView/SimultaneouslyScrollViewHandlerFactory.swift
+++ b/Sources/SimultaneouslyScrollView/SimultaneouslyScrollViewHandlerFactory.swift
@@ -1,10 +1,20 @@
 import Foundation
 
 /// Factory class to create `SimultaneouslyScrollViewHandler` instance
+@available(iOS 13, *)
+@available(tvOS, unavailable)
+@available(macOS, unavailable)
 public class SimultaneouslyScrollViewHandlerFactory {
+#if os(iOS)
     /// Creates a new `SimultaneouslyScrollViewHandler` instance
     /// - Returns: A new `SimultaneouslyScrollViewHandler` instance
     public static func create() -> SimultaneouslyScrollViewHandler {
         DefaultSimultaneouslyScrollViewHandler()
     }
+#else
+    public static func create() -> SimultaneouslyScrollViewHandler {
+        // Stub for other platforms
+        fatalError()
+    }
+#endif
 }


### PR DESCRIPTION
## Description

Issue: #6 

### Problem
When including the Package in a macOS project, there is no clear error message that the Package is unsupported on macOS. Instead Xcode shows an error message like `no such module: UIKit` which is not really helpful.

### Changes
This PR adds `@available` and `#if os(...)` checks to sure that a meaningful error message is shown in Xcode when using the package from macOS.